### PR TITLE
Update action.yml to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '.github/teams.yml'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'users'


### PR DESCRIPTION
Updating this action to node16.
I'm using Node16 because this is the same version tested by the main author of this action.

https://github.com/JulienKode/team-labeler-action

We are not using the original action because we made a small custom change to the action.